### PR TITLE
Remove unused dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,15 +54,7 @@
     "convex": "~1.16.5 || ~1.17.0"
   },
   "dependencies": {
-    "@types/react": "~18.2.79",
-    "convex-helpers": "^0.1.58",
-    "expo": "^51.0.32",
-    "expo-constants": "^16.0.2",
-    "expo-device": "^6.0.2",
-    "expo-notifications": "^0.28.16",
-    "expo-router": "^3.5.23",
-    "react-native": "^0.75.3",
-    "tamagui": "^1.110.3"
+    "convex-helpers": "^0.1.58"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,5 @@
     "outDir": "./dist",
     "skipLibCheck": true
   },
-  "include": ["./src/**/*"],
-  "extends": "expo/tsconfig.base"
+  "include": ["./src/**/*"]
 }


### PR DESCRIPTION
<!-- Describe your PR here. -->

The dependency `expo@^51.0.32` its currently crashing the EAS build twhen used in a expo 52 project, and its currently not being used in the actual code, only in `./example` but it has its own package.json

I've removed the rest of the dependencies that are not being used as well, to prevent possible problems similar to the expo dependency

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
