### PR TITLE
Feature/add creation time to get notifications for user

### DIFF
--- a/src/component/public.ts
+++ b/src/component/public.ts
@@ -138,11 +138,12 @@ export const getNotificationsForUser = query({
       .order("desc")
       .take(args.limit ?? DEFAULT_LIMIT);
     return notifications.map(
-      ({ _id, metadata, state, numPreviousFailures }) => ({
+      ({ _id, metadata, state, numPreviousFailures, _creationTime }) => ({
         id: _id,
         ...metadata,
         state: state,
         numPreviousFailures: numPreviousFailures,
+        creationTime: _creationTime,
       })
     );
   },

--- a/src/component/public.ts
+++ b/src/component/public.ts
@@ -109,8 +109,8 @@ export const getNotification = query({
     if (!notification) {
       return null;
     }
-    const { metadata, numPreviousFailures, state } = notification;
-    return { ...metadata, numPreviousFailures, state };
+    const { metadata, numPreviousFailures, state, _creationTime } = notification;
+    return { ...metadata, numPreviousFailures, state, _creationTime };
   },
 });
 
@@ -143,7 +143,7 @@ export const getNotificationsForUser = query({
         ...metadata,
         state: state,
         numPreviousFailures: numPreviousFailures,
-        creationTime: _creationTime,
+        _creationTime,
       })
     );
   },


### PR DESCRIPTION
## Added creationTime to notification objects

This PR exposes the `_creationTime` field from the database as `creationTime` in the notification objects returned by the `getNotificationsForUser` query. This enables:

- Time display for notifications in client applications

This change should be non-breaking.