### PR TITLE
Adding optional fields compatible with expo push notification api: subtitle and badge

### DIFF
--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -3,10 +3,11 @@ import { ObjectType, v } from "convex/values";
 
 export const notificationFields = {
   title: v.string(),
-  subtitle: v.string(),
+  subtitle: v.optional(v.string()),
   body: v.optional(v.string()),
   sound: v.optional(v.string()),
   data: v.optional(v.any()),
+  badge: v.optional(v.number())
 };
 
 export type NotificationFields = ObjectType<typeof notificationFields>;

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -3,6 +3,7 @@ import { ObjectType, v } from "convex/values";
 
 export const notificationFields = {
   title: v.string(),
+  subtitle: v.string(),
   body: v.optional(v.string()),
   sound: v.optional(v.string()),
   data: v.optional(v.any()),


### PR DESCRIPTION
<!-- Describe your PR here. -->

Updated the notification schema with:

```
subtitle: v.optional(v.string()),
badge: v.optional(v.number())
```
<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
