### PR TITLE
feat(lib): fix return type for getNotification and getNotificationsFo…

### DIFF
--- a/src/component/public.ts
+++ b/src/component/public.ts
@@ -102,6 +102,7 @@ export const getNotification = query({
       ...notificationFields,
       state: notificationState,
       numPreviousFailures: v.number(),
+      _creationTime: v.number(),
     })
   ),
   handler: async (ctx, args) => {
@@ -122,6 +123,7 @@ export const getNotificationsForUser = query({
       id: v.id("notifications"),
       state: notificationState,
       numPreviousFailures: v.number(),
+      _creationTime: v.number(),
     })
   ),
   handler: async (ctx, args) => {


### PR DESCRIPTION
### Fix return type for getNotification and getNotificationsForUser after a PR I made got merged few days ago

This PR adds the _creationTime field to return type for `getNotificationsForUser` and `getNotification` query.

The aforementioned PR is this: https://github.com/get-convex/expo-push-notifications/pull/11