### PR TITLE
Add support for `categoryIdentifier` and `subtitle`

### DIFF
--- a/src/component/internal.ts
+++ b/src/component/internal.ts
@@ -145,10 +145,12 @@ export const coordinateSendingPushNotifications = internalMutation({
           return {
             message: {
               to: n.token,
-              sound: n.metadata.sound ?? "default",
               title: n.metadata.title,
+              subtitle: n.metadata.subtitle ?? undefined,
               body: n.metadata.body ?? undefined,
+              sound: n.metadata.sound ?? "default",
               data: n.metadata.data ?? undefined,
+              categoryIdentifier: n.metadata.categoryIdentifier ?? undefined,
             },
             _id: n._id,
           };
@@ -193,10 +195,12 @@ export const action_sendPushNotifications = internalAction({
       v.object({
         message: v.object({
           to: v.string(),
-          sound: v.string(),
           title: v.string(),
+          subtitle: v.optional(v.string()),
           body: v.optional(v.string()),
+          sound: v.string(),
           data: v.optional(v.any()),
+          categoryIdentifier: v.optional(v.string()),
         }),
         _id: v.id("notifications"),
       })

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -3,9 +3,11 @@ import { ObjectType, v } from "convex/values";
 
 export const notificationFields = {
   title: v.string(),
+  subtitle: v.optional(v.string()),
   body: v.optional(v.string()),
   sound: v.optional(v.string()),
   data: v.optional(v.any()),
+  categoryIdentifier: v.optional(v.string()),
 };
 
 export type NotificationFields = ObjectType<typeof notificationFields>;


### PR DESCRIPTION
<!-- Describe your PR here. -->

Add `categoryIdentifier` to `notificationFields` in order to support Quick Actions in notifications (see [doc](https://docs.expo.dev/versions/latest/sdk/notifications/#manage-notification-categories-for-interactive-notifications) and this [issue](https://github.com/expo/expo/issues/10962#issuecomment-2556311639)).

Also add `subtitle` while I'm there (see [doc](https://docs.expo.dev/versions/latest/sdk/notifications/#notificationcontent)).

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
