### PR TITLE
Update the TypeScript version used

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
     "eslint-plugin-react-refresh": "^0.4.9",
     "globals": "^15.9.0",
-    "typescript": "^5.5.4",
+    "typescript": "^5.8.3",
     "typescript-eslint": "^8.31.0",
     "vite": "^5.4.1"
   }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "eslint": "^9.9.1",
     "globals": "^15.9.0",
     "prettier": "3.2.5",
-    "typescript": "~5.0.3",
+    "typescript": "^5.8.3",
     "typescript-eslint": "^8.4.0"
   },
   "main": "./dist/commonjs/client/index.js",


### PR DESCRIPTION
This fixes a `npm install` issue where the TypeScript version would not match the range of convex-helpers.