### PR TITLE
Replace `v.id('users')` with `v.string()` in pause/unpause args schema definition

### DIFF
--- a/src/component/public.ts
+++ b/src/component/public.ts
@@ -189,7 +189,7 @@ export const deleteNotificationsForUser = mutation({
 
 // e.g. pause sending notifications while the user is active in the app
 export const pauseNotificationsForUser = mutation({
-  args: { userId: v.id("users") },
+  args: { userId: v.string() },
   returns: v.null(),
   handler: async (ctx, { userId }) => {
     const existingToken = await ctx.db
@@ -208,7 +208,7 @@ export const pauseNotificationsForUser = mutation({
 });
 
 export const unpauseNotificationsForUser = mutation({
-  args: { userId: v.id("users") },
+  args: { userId: v.string() },
   returns: v.null(),
   handler: async (ctx, { userId }) => {
     const existingToken = await ctx.db


### PR DESCRIPTION
<!-- Describe your PR here. -->
## Description

This PR replaces the `v.id('users')` with `v.string()` in `pauseNotificationsForUser` and `unpauseNotificationsForUser` mutations args definition.

This change should resolve https://github.com/get-convex/expo-push-notifications/issues/17


<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
