### PR TITLE
fix: allow background push notifications by making title optional in …

### DIFF
--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -5,7 +5,7 @@ import { v } from "convex/values";
 export const notificationFields = {
   _contentAvailable: v.optional(v.boolean()),
   data: v.optional(v.any()),
-  title: v.string(),
+  title: v.optional(v.string()),
   body: v.optional(v.string()),
   ttl: v.optional(v.number()),
   expiration: v.optional(v.number()),


### PR DESCRIPTION
This PR fixes an issue where background push notifications could not be sent
because the `title` field was marked as required in the `sendPushNotifications` validator.

According to the official Expo documentation, `title` is optional for headless
(background) notifications: 
https://docs.expo.dev/versions/latest/sdk/notifications/#headless-background-notifications

Now, `sendPushNotifications` correctly allows sending notifications without a title,
enabling background notifications to function as expected.


----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
