### PR TITLE
fix: add a `return` statement after handling the non-ok response

### DIFF
--- a/src/component/internal.ts
+++ b/src/component/internal.ts
@@ -271,6 +271,7 @@ export const action_sendPushNotifications = internalAction({
         checkJobId: args.checkJobId,
         logLevel: ctx.logger.level,
       });
+      return;
     }
     const responseBody: {
       data: Array<


### PR DESCRIPTION
### Fix #30

## Summary
  Fixes a bug where the response body stream is read twice, causing `TypeError: Failed to execute 'json' on 'Response': body stream already read` when Expo's push notification API returns a non-OK response.

  ## Problem
  When the Expo API returns an error response (`!response.ok`), the code has a control flow bug:

  1. **Line 256**: First read - `await response.text()` consumes the response body for error logging
  2. **Line 273**: Missing `return` statement - function continues executing instead of exiting
  3. **Line 280**: Second read - `await response.json()` attempts to read the already-consumed body stream ❌

  ### Error Flow
  fetch() → response not ok →
    response.text() (consumes body) →
    mark as maybe_delivered →
    [MISSING RETURN] →
    response.json() ❌ (throws error)

  ## Solution
  Add a `return` statement after handling the non-OK response (line 273) to prevent the function from attempting to parse the response body as JSON after it has already been consumed.

  ## Changes
  - Added `return;` statement in the `!response.ok` error handling block to ensure the function exits after marking notifications as "maybe_delivered"
  - This prevents the subsequent `response.json()` call from trying to read an already-consumed response stream

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for push notifications to prevent unnecessary processing when network requests fail or the API responds with errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->