### PR TITLE
PushNotifications client token

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,15 @@ const pushNotifications = new PushNotifications(components.pushNotifications, {
 });
 ```
 
+If you have an Expo access token, pass it as `expoAccessToken` so requests to
+the Expo push API include the `Authorization: Bearer <token>` header:
+
+```ts
+const pushNotifications = new PushNotifications(components.pushNotifications, {
+  expoAccessToken: process.env.EXPO_ACCESS_TOKEN,
+});
+```
+
 The push notification sender can be shutdown gracefully, and then restarted
 using the `shutdown` and `restart` methods.
 

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -21,17 +21,19 @@ import type { ComponentApi } from "../component/_generated/component.js";
 export class PushNotifications<UserType extends string = GenericId<"users">> {
   private config: {
     logLevel: LogLevel;
+    expoAccessToken?: string;
   };
   constructor(
     public component: ComponentApi,
     config?: {
       logLevel?: LogLevel;
+      expoAccessToken?: string;
     },
   ) {
     this.component = component;
     this.config = {
-      ...(config ?? {}),
       logLevel: config?.logLevel ?? "ERROR",
+      expoAccessToken: config?.expoAccessToken,
     };
   }
 
@@ -47,6 +49,7 @@ export class PushNotifications<UserType extends string = GenericId<"users">> {
     return ctx.runMutation(this.component.public.recordPushNotificationToken, {
       ...args,
       logLevel: this.config.logLevel,
+      expoAccessToken: this.config.expoAccessToken,
     });
   }
 
@@ -59,6 +62,7 @@ export class PushNotifications<UserType extends string = GenericId<"users">> {
     return ctx.runMutation(this.component.public.removePushNotificationToken, {
       ...args,
       logLevel: this.config.logLevel,
+      expoAccessToken: this.config.expoAccessToken,
     });
   }
 
@@ -69,6 +73,7 @@ export class PushNotifications<UserType extends string = GenericId<"users">> {
     return ctx.runQuery(this.component.public.getStatusForUser, {
       ...args,
       logLevel: this.config.logLevel,
+      expoAccessToken: this.config.expoAccessToken,
     });
   }
 
@@ -97,6 +102,7 @@ export class PushNotifications<UserType extends string = GenericId<"users">> {
     return ctx.runMutation(this.component.public.sendPushNotification, {
       ...args,
       logLevel: this.config.logLevel,
+      expoAccessToken: this.config.expoAccessToken,
     });
   }
 
@@ -120,6 +126,7 @@ export class PushNotifications<UserType extends string = GenericId<"users">> {
     return ctx.runMutation(this.component.public.sendPushNotificationBatch, {
       ...args,
       logLevel: this.config.logLevel,
+      expoAccessToken: this.config.expoAccessToken,
     });
   }
 
@@ -131,6 +138,7 @@ export class PushNotifications<UserType extends string = GenericId<"users">> {
     return ctx.runQuery(this.component.public.getNotification, {
       ...args,
       logLevel: this.config.logLevel,
+      expoAccessToken: this.config.expoAccessToken,
     });
   }
 
@@ -144,6 +152,7 @@ export class PushNotifications<UserType extends string = GenericId<"users">> {
     return ctx.runQuery(this.component.public.getNotificationsForUser, {
       ...args,
       logLevel: this.config.logLevel,
+      expoAccessToken: this.config.expoAccessToken,
     });
   }
 
@@ -154,6 +163,7 @@ export class PushNotifications<UserType extends string = GenericId<"users">> {
     return ctx.runMutation(this.component.public.deleteNotificationsForUser, {
       ...args,
       logLevel: this.config.logLevel,
+      expoAccessToken: this.config.expoAccessToken,
     });
   }
 
@@ -167,6 +177,7 @@ export class PushNotifications<UserType extends string = GenericId<"users">> {
     return ctx.runMutation(this.component.public.pauseNotificationsForUser, {
       ...args,
       logLevel: this.config.logLevel,
+      expoAccessToken: this.config.expoAccessToken,
     });
   }
 
@@ -180,6 +191,7 @@ export class PushNotifications<UserType extends string = GenericId<"users">> {
     return ctx.runMutation(this.component.public.unpauseNotificationsForUser, {
       ...args,
       logLevel: this.config.logLevel,
+      expoAccessToken: this.config.expoAccessToken,
     });
   }
 
@@ -195,6 +207,7 @@ export class PushNotifications<UserType extends string = GenericId<"users">> {
   shutdown(ctx: RunMutationCtx) {
     return ctx.runMutation(this.component.public.shutdown, {
       logLevel: this.config.logLevel,
+      expoAccessToken: this.config.expoAccessToken,
     });
   }
 
@@ -208,6 +221,7 @@ export class PushNotifications<UserType extends string = GenericId<"users">> {
   restart(ctx: RunMutationCtx): Promise<boolean> {
     return ctx.runMutation(this.component.public.restart, {
       logLevel: this.config.logLevel,
+      expoAccessToken: this.config.expoAccessToken,
     });
   }
 }

--- a/src/component/_generated/component.ts
+++ b/src/component/_generated/component.ts
@@ -27,14 +27,22 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
       deleteNotificationsForUser: FunctionReference<
         "mutation",
         "internal",
-        { logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR"; userId: string },
+        {
+          expoAccessToken?: string;
+          logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR";
+          userId: string;
+        },
         null,
         Name
       >;
       getNotification: FunctionReference<
         "query",
         "internal",
-        { id: string; logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR" },
+        {
+          expoAccessToken?: string;
+          id: string;
+          logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR";
+        },
         null | {
           _contentAvailable?: boolean;
           _creationTime: number;
@@ -71,6 +79,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         "query",
         "internal",
         {
+          expoAccessToken?: string;
           limit?: number;
           logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR";
           userId: string;
@@ -111,14 +120,22 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
       getStatusForUser: FunctionReference<
         "query",
         "internal",
-        { logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR"; userId: string },
+        {
+          expoAccessToken?: string;
+          logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR";
+          userId: string;
+        },
         { hasToken: boolean; paused: boolean },
         Name
       >;
       pauseNotificationsForUser: FunctionReference<
         "mutation",
         "internal",
-        { logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR"; userId: string },
+        {
+          expoAccessToken?: string;
+          logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR";
+          userId: string;
+        },
         null,
         Name
       >;
@@ -126,6 +143,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         "mutation",
         "internal",
         {
+          expoAccessToken?: string;
           logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR";
           pushToken: string;
           userId: string;
@@ -136,14 +154,18 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
       removePushNotificationToken: FunctionReference<
         "mutation",
         "internal",
-        { logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR"; userId: string },
+        {
+          expoAccessToken?: string;
+          logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR";
+          userId: string;
+        },
         null,
         Name
       >;
       restart: FunctionReference<
         "mutation",
         "internal",
-        { logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR" },
+        { expoAccessToken?: string; logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR" },
         boolean,
         Name
       >;
@@ -152,6 +174,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         "internal",
         {
           allowUnregisteredTokens?: boolean;
+          expoAccessToken?: string;
           logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR";
           notification: {
             _contentAvailable?: boolean;
@@ -183,6 +206,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         "internal",
         {
           allowUnregisteredTokens?: boolean;
+          expoAccessToken?: string;
           logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR";
           notifications: Array<{
             notification: {
@@ -214,14 +238,18 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
       shutdown: FunctionReference<
         "mutation",
         "internal",
-        { logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR" },
+        { expoAccessToken?: string; logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR" },
         { data?: any; message: string },
         Name
       >;
       unpauseNotificationsForUser: FunctionReference<
         "mutation",
         "internal",
-        { logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR"; userId: string },
+        {
+          expoAccessToken?: string;
+          logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR";
+          userId: string;
+        },
         null,
         Name
       >;

--- a/src/component/functions.ts
+++ b/src/component/functions.ts
@@ -4,48 +4,87 @@ import {
   customMutation,
   customQuery,
 } from "convex-helpers/server/customFunctions";
+import { v } from "convex/values";
 import * as VanillaConvex from "./_generated/server.js";
 import { Logger, logLevelValidator } from "../logging/index.js";
 
+const expoAccessTokenValidator = v.optional(v.string());
+
 export const query = customQuery(VanillaConvex.query, {
-  args: { logLevel: logLevelValidator },
+  args: { logLevel: logLevelValidator, expoAccessToken: expoAccessTokenValidator },
   input: async (ctx, args) => {
-    return { ctx: { logger: new Logger(args.logLevel) }, args: {} };
+    return {
+      ctx: {
+        logger: new Logger(args.logLevel),
+        expoAccessToken: args.expoAccessToken,
+      },
+      args: {},
+    };
   },
 });
 
 export const mutation = customMutation(VanillaConvex.mutation, {
-  args: { logLevel: logLevelValidator },
+  args: { logLevel: logLevelValidator, expoAccessToken: expoAccessTokenValidator },
   input: async (ctx, args) => {
-    return { ctx: { logger: new Logger(args.logLevel) }, args: {} };
+    return {
+      ctx: {
+        logger: new Logger(args.logLevel),
+        expoAccessToken: args.expoAccessToken,
+      },
+      args: {},
+    };
   },
 });
 
 export const action = customAction(VanillaConvex.action, {
-  args: { logLevel: logLevelValidator },
+  args: { logLevel: logLevelValidator, expoAccessToken: expoAccessTokenValidator },
   input: async (ctx, args) => {
-    return { ctx: { logger: new Logger(args.logLevel) }, args: {} };
+    return {
+      ctx: {
+        logger: new Logger(args.logLevel),
+        expoAccessToken: args.expoAccessToken,
+      },
+      args: {},
+    };
   },
 });
 
 export const internalQuery = customQuery(VanillaConvex.internalQuery, {
-  args: { logLevel: logLevelValidator },
+  args: { logLevel: logLevelValidator, expoAccessToken: expoAccessTokenValidator },
   input: async (ctx, args) => {
-    return { ctx: { logger: new Logger(args.logLevel) }, args: {} };
+    return {
+      ctx: {
+        logger: new Logger(args.logLevel),
+        expoAccessToken: args.expoAccessToken,
+      },
+      args: {},
+    };
   },
 });
 
 export const internalMutation = customMutation(VanillaConvex.internalMutation, {
-  args: { logLevel: logLevelValidator },
+  args: { logLevel: logLevelValidator, expoAccessToken: expoAccessTokenValidator },
   input: async (ctx, args) => {
-    return { ctx: { logger: new Logger(args.logLevel) }, args: {} };
+    return {
+      ctx: {
+        logger: new Logger(args.logLevel),
+        expoAccessToken: args.expoAccessToken,
+      },
+      args: {},
+    };
   },
 });
 
 export const internalAction = customAction(VanillaConvex.internalAction, {
-  args: { logLevel: logLevelValidator },
+  args: { logLevel: logLevelValidator, expoAccessToken: expoAccessTokenValidator },
   input: async (ctx, args) => {
-    return { ctx: { logger: new Logger(args.logLevel) }, args: {} };
+    return {
+      ctx: {
+        logger: new Logger(args.logLevel),
+        expoAccessToken: args.expoAccessToken,
+      },
+      args: {},
+    };
   },
 });
 

--- a/src/component/helpers.ts
+++ b/src/component/helpers.ts
@@ -41,6 +41,7 @@ export async function ensureCoordinator(ctx: MutationCtx) {
     internal.internal.coordinateSendingPushNotifications,
     {
       logLevel: ctx.logger.level,
+      expoAccessToken: ctx.expoAccessToken,
     },
   );
   const coordinatorId = await ctx.db.insert("senderCoordinator", {

--- a/src/component/internal.ts
+++ b/src/component/internal.ts
@@ -134,6 +134,7 @@ export const coordinateSendingPushNotifications = internalMutation({
       {
         notificationIds: notificationsToSend.map((n) => n._id),
         logLevel: ctx.logger.level,
+        expoAccessToken: ctx.expoAccessToken,
       },
     );
 
@@ -165,6 +166,7 @@ export const coordinateSendingPushNotifications = internalMutation({
           };
         }),
         logLevel: ctx.logger.level,
+        expoAccessToken: ctx.expoAccessToken,
       },
     );
     await ctx.db.insert("senders", {
@@ -220,13 +222,17 @@ export const action_sendPushNotifications = internalAction({
     let response: Response;
     try {
       // https://docs.expo.dev/push-notifications/sending-notifications/#http2-api
+      const headers: Record<string, string> = {
+        Accept: "application/json",
+        "Accept-encoding": "gzip, deflate",
+        "Content-Type": "application/json",
+      };
+      if (ctx.expoAccessToken) {
+        headers.Authorization = `Bearer ${ctx.expoAccessToken}`;
+      }
       response = await fetch("https://exp.host/--/api/v2/push/send", {
         method: "POST",
-        headers: {
-          Accept: "application/json",
-          "Accept-encoding": "gzip, deflate",
-          "Content-Type": "application/json",
-        },
+        headers,
         body: JSON.stringify(args.notifications.map((n) => n.message)),
       });
     } catch (_e) {
@@ -248,6 +254,7 @@ export const action_sendPushNotifications = internalAction({
         }),
         checkJobId: args.checkJobId,
         logLevel: ctx.logger.level,
+        expoAccessToken: ctx.expoAccessToken,
       });
       return;
     }
@@ -270,6 +277,7 @@ export const action_sendPushNotifications = internalAction({
         }),
         checkJobId: args.checkJobId,
         logLevel: ctx.logger.level,
+        expoAccessToken: ctx.expoAccessToken,
       });
       return;
     }
@@ -309,6 +317,7 @@ export const action_sendPushNotifications = internalAction({
       notifications: notificationStates,
       checkJobId: args.checkJobId,
       logLevel: ctx.logger.level,
+      expoAccessToken: ctx.expoAccessToken,
     });
   },
 });


### PR DESCRIPTION
Adds an `expoAccessToken` config field to the `PushNotifications` client to authenticate requests to the Expo push API.

The `expoAccessToken` is passed as an `Authorization: Bearer <token>` header to the Expo push API. The `src/component/_generated/component.ts` file was manually updated to reflect the new argument due to codegen issues during development.

---
<a href="https://cursor.com/background-agent?bcId=bc-94ace241-24c2-41bc-95ff-918dd77eba68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-94ace241-24c2-41bc-95ff-918dd77eba68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

