### PR TITLE
add expoAccessToken option

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,19 @@ const pushNotifications = new PushNotifications(components.pushNotifications, {
 });
 ```
 
+To authenticate to the Expo push API (required if your Expo project has
+[Enhanced Security for Push Notifications](https://docs.expo.dev/push-notifications/sending-notifications/#additional-security)
+enabled), provide an `expoAccessToken`:
+
+```ts
+const pushNotifications = new PushNotifications(components.pushNotifications, {
+  expoAccessToken: process.env.EXPO_ACCESS_TOKEN,
+});
+```
+
+When set, the token is sent as `Authorization: Bearer <token>` on every call to
+`https://exp.host/--/api/v2/push/send`.
+
 The push notification sender can be shutdown gracefully, and then restarted
 using the `shutdown` and `restart` methods.
 

--- a/README.md
+++ b/README.md
@@ -237,9 +237,6 @@ const pushNotifications = new PushNotifications(components.pushNotifications, {
 });
 ```
 
-When set, the token is sent as `Authorization: Bearer <token>` on every call to
-`https://exp.host/--/api/v2/push/send`.
-
 The push notification sender can be shutdown gracefully, and then restarted
 using the `shutdown` and `restart` methods.
 

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -29,11 +29,8 @@ export class PushNotifications<UserType extends string = GenericId<"users">> {
       logLevel?: LogLevel;
       /**
        * Expo access token used to authenticate requests to the Expo push API.
-       *
-       * When set, the token is sent as `Authorization: Bearer <token>` on every
-       * call to `https://exp.host/--/api/v2/push/send`. Required when the
-       * sending Expo project has Enhanced Security for Push Notifications
-       * enabled.
+       * Required when the sending Expo project has Enhanced Security for Push
+       * Notifications enabled.
        */
       expoAccessToken?: string;
     },

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -21,17 +21,28 @@ import type { ComponentApi } from "../component/_generated/component.js";
 export class PushNotifications<UserType extends string = GenericId<"users">> {
   private config: {
     logLevel: LogLevel;
+    expoAccessToken?: string;
   };
   constructor(
     public component: ComponentApi,
     config?: {
       logLevel?: LogLevel;
+      /**
+       * Expo access token used to authenticate requests to the Expo push API.
+       *
+       * When set, the token is sent as `Authorization: Bearer <token>` on every
+       * call to `https://exp.host/--/api/v2/push/send`. Required when the
+       * sending Expo project has Enhanced Security for Push Notifications
+       * enabled.
+       */
+      expoAccessToken?: string;
     },
   ) {
     this.component = component;
     this.config = {
       ...(config ?? {}),
       logLevel: config?.logLevel ?? "ERROR",
+      expoAccessToken: config?.expoAccessToken,
     };
   }
 
@@ -47,6 +58,7 @@ export class PushNotifications<UserType extends string = GenericId<"users">> {
     return ctx.runMutation(this.component.public.recordPushNotificationToken, {
       ...args,
       logLevel: this.config.logLevel,
+      expoAccessToken: this.config.expoAccessToken,
     });
   }
 
@@ -59,6 +71,7 @@ export class PushNotifications<UserType extends string = GenericId<"users">> {
     return ctx.runMutation(this.component.public.removePushNotificationToken, {
       ...args,
       logLevel: this.config.logLevel,
+      expoAccessToken: this.config.expoAccessToken,
     });
   }
 
@@ -69,6 +82,7 @@ export class PushNotifications<UserType extends string = GenericId<"users">> {
     return ctx.runQuery(this.component.public.getStatusForUser, {
       ...args,
       logLevel: this.config.logLevel,
+      expoAccessToken: this.config.expoAccessToken,
     });
   }
 
@@ -97,6 +111,7 @@ export class PushNotifications<UserType extends string = GenericId<"users">> {
     return ctx.runMutation(this.component.public.sendPushNotification, {
       ...args,
       logLevel: this.config.logLevel,
+      expoAccessToken: this.config.expoAccessToken,
     });
   }
 
@@ -120,6 +135,7 @@ export class PushNotifications<UserType extends string = GenericId<"users">> {
     return ctx.runMutation(this.component.public.sendPushNotificationBatch, {
       ...args,
       logLevel: this.config.logLevel,
+      expoAccessToken: this.config.expoAccessToken,
     });
   }
 
@@ -131,6 +147,7 @@ export class PushNotifications<UserType extends string = GenericId<"users">> {
     return ctx.runQuery(this.component.public.getNotification, {
       ...args,
       logLevel: this.config.logLevel,
+      expoAccessToken: this.config.expoAccessToken,
     });
   }
 
@@ -144,6 +161,7 @@ export class PushNotifications<UserType extends string = GenericId<"users">> {
     return ctx.runQuery(this.component.public.getNotificationsForUser, {
       ...args,
       logLevel: this.config.logLevel,
+      expoAccessToken: this.config.expoAccessToken,
     });
   }
 
@@ -154,6 +172,7 @@ export class PushNotifications<UserType extends string = GenericId<"users">> {
     return ctx.runMutation(this.component.public.deleteNotificationsForUser, {
       ...args,
       logLevel: this.config.logLevel,
+      expoAccessToken: this.config.expoAccessToken,
     });
   }
 
@@ -167,6 +186,7 @@ export class PushNotifications<UserType extends string = GenericId<"users">> {
     return ctx.runMutation(this.component.public.pauseNotificationsForUser, {
       ...args,
       logLevel: this.config.logLevel,
+      expoAccessToken: this.config.expoAccessToken,
     });
   }
 
@@ -180,6 +200,7 @@ export class PushNotifications<UserType extends string = GenericId<"users">> {
     return ctx.runMutation(this.component.public.unpauseNotificationsForUser, {
       ...args,
       logLevel: this.config.logLevel,
+      expoAccessToken: this.config.expoAccessToken,
     });
   }
 
@@ -195,6 +216,7 @@ export class PushNotifications<UserType extends string = GenericId<"users">> {
   shutdown(ctx: RunMutationCtx) {
     return ctx.runMutation(this.component.public.shutdown, {
       logLevel: this.config.logLevel,
+      expoAccessToken: this.config.expoAccessToken,
     });
   }
 
@@ -208,6 +230,7 @@ export class PushNotifications<UserType extends string = GenericId<"users">> {
   restart(ctx: RunMutationCtx): Promise<boolean> {
     return ctx.runMutation(this.component.public.restart, {
       logLevel: this.config.logLevel,
+      expoAccessToken: this.config.expoAccessToken,
     });
   }
 }

--- a/src/component/_generated/component.ts
+++ b/src/component/_generated/component.ts
@@ -27,14 +27,22 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
       deleteNotificationsForUser: FunctionReference<
         "mutation",
         "internal",
-        { logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR"; userId: string },
+        {
+          expoAccessToken?: string;
+          logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR";
+          userId: string;
+        },
         null,
         Name
       >;
       getNotification: FunctionReference<
         "query",
         "internal",
-        { id: string; logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR" },
+        {
+          expoAccessToken?: string;
+          id: string;
+          logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR";
+        },
         null | {
           _contentAvailable?: boolean;
           _creationTime: number;
@@ -71,6 +79,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         "query",
         "internal",
         {
+          expoAccessToken?: string;
           limit?: number;
           logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR";
           userId: string;
@@ -111,14 +120,22 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
       getStatusForUser: FunctionReference<
         "query",
         "internal",
-        { logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR"; userId: string },
+        {
+          expoAccessToken?: string;
+          logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR";
+          userId: string;
+        },
         { hasToken: boolean; paused: boolean },
         Name
       >;
       pauseNotificationsForUser: FunctionReference<
         "mutation",
         "internal",
-        { logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR"; userId: string },
+        {
+          expoAccessToken?: string;
+          logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR";
+          userId: string;
+        },
         null,
         Name
       >;
@@ -126,6 +143,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         "mutation",
         "internal",
         {
+          expoAccessToken?: string;
           logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR";
           pushToken: string;
           userId: string;
@@ -136,14 +154,21 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
       removePushNotificationToken: FunctionReference<
         "mutation",
         "internal",
-        { logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR"; userId: string },
+        {
+          expoAccessToken?: string;
+          logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR";
+          userId: string;
+        },
         null,
         Name
       >;
       restart: FunctionReference<
         "mutation",
         "internal",
-        { logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR" },
+        {
+          expoAccessToken?: string;
+          logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR";
+        },
         boolean,
         Name
       >;
@@ -152,6 +177,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         "internal",
         {
           allowUnregisteredTokens?: boolean;
+          expoAccessToken?: string;
           logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR";
           notification: {
             _contentAvailable?: boolean;
@@ -183,6 +209,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         "internal",
         {
           allowUnregisteredTokens?: boolean;
+          expoAccessToken?: string;
           logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR";
           notifications: Array<{
             notification: {
@@ -214,14 +241,21 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
       shutdown: FunctionReference<
         "mutation",
         "internal",
-        { logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR" },
+        {
+          expoAccessToken?: string;
+          logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR";
+        },
         { data?: any; message: string },
         Name
       >;
       unpauseNotificationsForUser: FunctionReference<
         "mutation",
         "internal",
-        { logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR"; userId: string },
+        {
+          expoAccessToken?: string;
+          logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR";
+          userId: string;
+        },
         null,
         Name
       >;

--- a/src/component/batch.ts
+++ b/src/component/batch.ts
@@ -41,10 +41,15 @@ const notificationPool = new Workpool(
 
 type SchedulingCtx = RawMutationCtx & {
   logger?: { level: LogLevel };
+  expoAccessToken?: string;
 };
 
 function getLogLevel(ctx: SchedulingCtx): LogLevel {
   return ctx.logger?.level ?? "INFO";
+}
+
+function getExpoAccessToken(ctx: SchedulingCtx): string | undefined {
+  return ctx.expoAccessToken;
 }
 
 async function upsertNextBatchRun(
@@ -147,6 +152,7 @@ async function syncNextBatchRun(
       reloop: false,
       segment,
       logLevel: getLogLevel(ctx),
+      expoAccessToken: getExpoAccessToken(ctx),
     },
   );
 
@@ -232,14 +238,18 @@ export const makeBatch = internalMutation({
     await notificationPool.enqueueAction(
       ctx,
       internal.expo.callExpoPushApiWithBatch,
-      { notificationIds, logLevel: ctx.logger.level },
+      {
+        notificationIds,
+        logLevel: ctx.logger.level,
+        expoAccessToken: ctx.expoAccessToken,
+      },
       {
         retry: {
           maxAttempts: options.retryAttempts,
           initialBackoffMs: options.initialBackoffMs,
           base: 2,
         },
-        context: { notificationIds },
+        context: { notificationIds, expoAccessToken: ctx.expoAccessToken },
         onComplete: internal.batch.onPushComplete,
       },
     );
@@ -250,6 +260,7 @@ export const makeBatch = internalMutation({
       reloop: true,
       segment: args.segment,
       logLevel: ctx.logger.level,
+      expoAccessToken: ctx.expoAccessToken,
     });
     await upsertNextBatchRun(ctx, runId, args.segment);
 
@@ -260,9 +271,14 @@ export const makeBatch = internalMutation({
 export const onPushComplete = notificationPool.defineOnComplete({
   context: v.object({
     notificationIds: v.array(v.id("notifications")),
+    expoAccessToken: v.optional(v.string()),
   }),
   handler: async (ctx, args) => {
-    const options = await getRuntimeConfig(ctx);
+    const ctxWithToken: SchedulingCtx = {
+      ...(ctx as RawMutationCtx),
+      expoAccessToken: args.context.expoAccessToken,
+    };
+    const options = await getRuntimeConfig(ctxWithToken);
 
     if (args.result.kind === "canceled") {
       for (const id of args.context.notificationIds) {
@@ -316,6 +332,6 @@ export const onPushComplete = notificationPool.defineOnComplete({
       }
     }
 
-    await scheduleBatchRun(ctx, options);
+    await scheduleBatchRun(ctxWithToken, options);
   },
 });

--- a/src/component/batch.ts
+++ b/src/component/batch.ts
@@ -65,7 +65,7 @@ async function upsertNextBatchRun(
   await ctx.db.insert("nextBatchRun", { runId, segment });
 }
 
-async function getRuntimeConfig(ctx: SchedulingCtx): Promise<RuntimeConfig> {
+async function getRuntimeConfig(ctx: RawMutationCtx): Promise<RuntimeConfig> {
   const options = await ctx.db.query("lastOptions").unique();
   if (options) {
     return {
@@ -274,11 +274,7 @@ export const onPushComplete = notificationPool.defineOnComplete({
     expoAccessToken: v.optional(v.string()),
   }),
   handler: async (ctx, args) => {
-    const ctxWithToken: SchedulingCtx = {
-      ...(ctx as RawMutationCtx),
-      expoAccessToken: args.context.expoAccessToken,
-    };
-    const options = await getRuntimeConfig(ctxWithToken);
+    const options = await getRuntimeConfig(ctx);
 
     if (args.result.kind === "canceled") {
       for (const id of args.context.notificationIds) {
@@ -332,6 +328,6 @@ export const onPushComplete = notificationPool.defineOnComplete({
       }
     }
 
-    await scheduleBatchRun(ctxWithToken, options);
+    await scheduleBatchRun(ctx, options);
   },
 });

--- a/src/component/expo.ts
+++ b/src/component/expo.ts
@@ -81,15 +81,20 @@ export const callExpoPushApiWithBatch = internalAction({
       controller.abort();
     }, EXPO_REQUEST_TIMEOUT_MS);
 
+    const headers: Record<string, string> = {
+      Accept: "application/json",
+      "Accept-encoding": "gzip, deflate",
+      "Content-Type": "application/json",
+    };
+    if (ctx.expoAccessToken) {
+      headers.Authorization = `Bearer ${ctx.expoAccessToken}`;
+    }
+
     let response: Response;
     try {
       response = await fetch("https://exp.host/--/api/v2/push/send", {
         method: "POST",
-        headers: {
-          Accept: "application/json",
-          "Accept-encoding": "gzip, deflate",
-          "Content-Type": "application/json",
-        },
+        headers,
         body: JSON.stringify(
           inProgress.map((notification) => ({
             to: notification.token,

--- a/src/component/functions.ts
+++ b/src/component/functions.ts
@@ -4,49 +4,79 @@ import {
   customMutation,
   customQuery,
 } from "convex-helpers/server/customFunctions";
+import { v } from "convex/values";
 import * as VanillaConvex from "./_generated/server.js";
 import { Logger, logLevelValidator } from "../logging/index.js";
 
+const wrapperArgs = {
+  logLevel: logLevelValidator,
+  expoAccessToken: v.optional(v.string()),
+};
+
 export const query = customQuery(VanillaConvex.query, {
-  args: { logLevel: logLevelValidator },
-  input: async (ctx, args) => {
-    return { ctx: { logger: new Logger(args.logLevel) }, args: {} };
-  },
+  args: wrapperArgs,
+  input: async (_ctx, args) => ({
+    ctx: {
+      logger: new Logger(args.logLevel),
+      expoAccessToken: args.expoAccessToken,
+    },
+    args: {},
+  }),
 });
 
 export const mutation = customMutation(VanillaConvex.mutation, {
-  args: { logLevel: logLevelValidator },
-  input: async (ctx, args) => {
-    return { ctx: { logger: new Logger(args.logLevel) }, args: {} };
-  },
+  args: wrapperArgs,
+  input: async (_ctx, args) => ({
+    ctx: {
+      logger: new Logger(args.logLevel),
+      expoAccessToken: args.expoAccessToken,
+    },
+    args: {},
+  }),
 });
 
 export const action = customAction(VanillaConvex.action, {
-  args: { logLevel: logLevelValidator },
-  input: async (ctx, args) => {
-    return { ctx: { logger: new Logger(args.logLevel) }, args: {} };
-  },
+  args: wrapperArgs,
+  input: async (_ctx, args) => ({
+    ctx: {
+      logger: new Logger(args.logLevel),
+      expoAccessToken: args.expoAccessToken,
+    },
+    args: {},
+  }),
 });
 
 export const internalQuery = customQuery(VanillaConvex.internalQuery, {
-  args: { logLevel: logLevelValidator },
-  input: async (ctx, args) => {
-    return { ctx: { logger: new Logger(args.logLevel) }, args: {} };
-  },
+  args: wrapperArgs,
+  input: async (_ctx, args) => ({
+    ctx: {
+      logger: new Logger(args.logLevel),
+      expoAccessToken: args.expoAccessToken,
+    },
+    args: {},
+  }),
 });
 
 export const internalMutation = customMutation(VanillaConvex.internalMutation, {
-  args: { logLevel: logLevelValidator },
-  input: async (ctx, args) => {
-    return { ctx: { logger: new Logger(args.logLevel) }, args: {} };
-  },
+  args: wrapperArgs,
+  input: async (_ctx, args) => ({
+    ctx: {
+      logger: new Logger(args.logLevel),
+      expoAccessToken: args.expoAccessToken,
+    },
+    args: {},
+  }),
 });
 
 export const internalAction = customAction(VanillaConvex.internalAction, {
-  args: { logLevel: logLevelValidator },
-  input: async (ctx, args) => {
-    return { ctx: { logger: new Logger(args.logLevel) }, args: {} };
-  },
+  args: wrapperArgs,
+  input: async (_ctx, args) => ({
+    ctx: {
+      logger: new Logger(args.logLevel),
+      expoAccessToken: args.expoAccessToken,
+    },
+    args: {},
+  }),
 });
 
 export type MutationCtx = CustomCtx<typeof mutation>;

--- a/src/component/lib.test.ts
+++ b/src/component/lib.test.ts
@@ -79,7 +79,7 @@ describe("push notification pipeline", () => {
     );
 
     const fetchMock = vi.fn(
-      async () =>
+      async (_url: string, _init?: RequestInit) =>
         new Response(
           JSON.stringify({
             data: [
@@ -105,8 +105,10 @@ describe("push notification pipeline", () => {
       ],
     });
 
-    const sentHeaders = (fetchMock.mock.calls[0]?.[1] as RequestInit)
-      .headers as Record<string, string>;
+    const sentHeaders = fetchMock.mock.calls[0]![1]!.headers as Record<
+      string,
+      string
+    >;
     expect(sentHeaders.Authorization).toBeUndefined();
   });
 
@@ -123,7 +125,7 @@ describe("push notification pipeline", () => {
     );
 
     const fetchMock = vi.fn(
-      async () =>
+      async (_url: string, _init?: RequestInit) =>
         new Response(
           JSON.stringify({ data: [{ status: "ok", id: "ticket-x" }] }),
           { status: 200 },
@@ -137,8 +139,10 @@ describe("push notification pipeline", () => {
       expoAccessToken: "secret-abc",
     });
 
-    const sentHeaders = (fetchMock.mock.calls[0]?.[1] as RequestInit)
-      .headers as Record<string, string>;
+    const sentHeaders = fetchMock.mock.calls[0]![1]!.headers as Record<
+      string,
+      string
+    >;
     expect(sentHeaders.Authorization).toBe("Bearer secret-abc");
   });
 

--- a/src/component/lib.test.ts
+++ b/src/component/lib.test.ts
@@ -78,21 +78,19 @@ describe("push notification pipeline", () => {
       }),
     );
 
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(
-        async () =>
-          new Response(
-            JSON.stringify({
-              data: [
-                { status: "ok", id: "ticket-1" },
-                { status: "error", message: "invalid token" },
-              ],
-            }),
-            { status: 200 },
-          ),
-      ),
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            data: [
+              { status: "ok", id: "ticket-1" },
+              { status: "error", message: "invalid token" },
+            ],
+          }),
+          { status: 200 },
+        ),
     );
+    vi.stubGlobal("fetch", fetchMock);
 
     const result = await t.action(internal.expo.callExpoPushApiWithBatch, {
       notificationIds: [id1, id2],
@@ -106,6 +104,42 @@ describe("push notification pipeline", () => {
         { id: id2, state: "failed", errorMessage: "invalid token" },
       ],
     });
+
+    const sentHeaders = (fetchMock.mock.calls[0]?.[1] as RequestInit)
+      .headers as Record<string, string>;
+    expect(sentHeaders.Authorization).toBeUndefined();
+  });
+
+  it("sends Authorization: Bearer header when expoAccessToken is configured", async () => {
+    const id = await t.run(async (ctx: any) =>
+      ctx.db.insert("notifications", {
+        token: "ExponentPushToken[x]",
+        metadata: { title: "x" },
+        state: "in_progress",
+        numPreviousFailures: 0,
+        segment: 1,
+        finalizedAt: FINALIZED_EPOCH,
+      }),
+    );
+
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({ data: [{ status: "ok", id: "ticket-x" }] }),
+          { status: 200 },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await t.action(internal.expo.callExpoPushApiWithBatch, {
+      notificationIds: [id],
+      logLevel: "ERROR",
+      expoAccessToken: "secret-abc",
+    });
+
+    const sentHeaders = (fetchMock.mock.calls[0]?.[1] as RequestInit)
+      .headers as Record<string, string>;
+    expect(sentHeaders.Authorization).toBe("Bearer secret-abc");
   });
 
   it("marks MessageRateExceeded ticket errors as retryable", async () => {

--- a/src/component/public.ts
+++ b/src/component/public.ts
@@ -230,6 +230,7 @@ export const deleteNotificationsForUser = mutation({
       await ctx.scheduler.runAfter(0, api.public.deleteNotificationsForUser, {
         ...args,
         logLevel: ctx.logger.level,
+        expoAccessToken: ctx.expoAccessToken,
       });
     }
   },


### PR DESCRIPTION
Optionally allow setting `expoAccessToken` in `config` to authenticate requests to the Expo push API.