### PR TITLE
add EXPO_ACCESS_TOKEN component env

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,35 @@ const pushNotifications = new PushNotifications<Email>(
 );
 ```
 
+### Authenticating with an Expo access token (optional)
+
+If your Expo project has
+[enhanced push security](https://docs.expo.dev/push-notifications/sending-notifications/#additional-security)
+enabled, every request to the Expo push API must include an access token. To
+opt in, generate a token from your Expo access tokens settings,
+set it as a Convex environment variable in your deployment:
+
+```bash
+npx convex env set EXPO_ACCESS_TOKEN <your-token>
+```
+
+and forward it to the component via `app.use`:
+
+```ts
+// convex/convex.config.ts
+const app = defineApp({
+  env: {
+    EXPO_ACCESS_TOKEN: v.optional(v.string()),
+  },
+});
+
+app.use(pushNotifications, {
+  env: {
+    EXPO_ACCESS_TOKEN: app.env.EXPO_ACCESS_TOKEN,
+  }
+});
+```
+
 ## Registering a user for push notifications
 
 Get a user's push notification token following the Expo documentation

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ import { defineApp } from "convex/server";
 import pushNotifications from "@convex-dev/expo-push-notifications/convex.config.js";
 
 const app = defineApp();
-app.use(pushNotifications);
+app.use(pushNotifications, { env: {} });
 // other components
 
 export default app;

--- a/example/convex/_generated/server.d.ts
+++ b/example/convex/_generated/server.d.ts
@@ -22,6 +22,13 @@ import {
 import type { DataModel } from "./dataModel.js";
 
 /**
+ * Typesafe environment variables declared in `convex.config.ts`.
+ */
+type Env = {
+  readonly EXPO_ACCESS_TOKEN: string | undefined;
+};
+
+/**
  * Define a query in this Convex app's public API.
  *
  * This function will be allowed to read your Convex database and will be accessible from the client.
@@ -94,6 +101,11 @@ export declare const internalAction: ActionBuilder<DataModel, "internal">;
  * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
  */
 export declare const httpAction: HttpActionBuilder;
+
+/**
+ * Typesafe environment variables declared in `convex.config.ts`.
+ */
+export declare const env: Env;
 
 /**
  * A set of services for use within Convex query functions.

--- a/example/convex/_generated/server.js
+++ b/example/convex/_generated/server.js
@@ -91,3 +91,8 @@ export const internalAction = internalActionGeneric;
  * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
  */
 export const httpAction = httpActionGeneric;
+
+/**
+ * Typesafe environment variables declared in `convex.config.ts`.
+ */
+export const env = process.env;

--- a/example/convex/convex.config.ts
+++ b/example/convex/convex.config.ts
@@ -1,7 +1,17 @@
 import { defineApp } from "convex/server";
 import pushNotifications from "@convex-dev/expo-push-notifications/convex.config.js";
+import { v } from "convex/values";
 
-const app = defineApp();
-app.use(pushNotifications);
+const app = defineApp({
+  env: {
+    EXPO_ACCESS_TOKEN: v.optional(v.string()),
+  },
+});
+
+app.use(pushNotifications, {
+  env: {
+    EXPO_ACCESS_TOKEN: app.env.EXPO_ACCESS_TOKEN,
+  }
+});
 
 export default app;

--- a/src/component/_generated/server.ts
+++ b/src/component/_generated/server.ts
@@ -31,6 +31,13 @@ import {
 import type { DataModel } from "./dataModel.js";
 
 /**
+ * Typesafe environment variables declared in `convex.config.ts`.
+ */
+type Env = {
+  readonly EXPO_ACCESS_TOKEN: string | undefined;
+};
+
+/**
  * Define a query in this Convex app's public API.
  *
  * This function will be allowed to read your Convex database and will be accessible from the client.
@@ -106,6 +113,7 @@ export const internalAction: ActionBuilder<DataModel, "internal"> =
  * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
  */
 export const httpAction: HttpActionBuilder = httpActionGeneric;
+export const env: Env = process.env as unknown as Env;
 
 /**
  * A set of services for use within Convex query functions.

--- a/src/component/convex.config.ts
+++ b/src/component/convex.config.ts
@@ -1,8 +1,13 @@
 import { defineComponent } from "convex/server";
+import { v } from "convex/values";
 import rateLimiter from "@convex-dev/rate-limiter/convex.config";
 import workpool from "@convex-dev/workpool/convex.config";
 
-const component = defineComponent("pushNotifications");
+const component = defineComponent("pushNotifications", {
+  env: {
+    EXPO_ACCESS_TOKEN: v.optional(v.string()),
+  },
+});
 component.use(rateLimiter);
 component.use(workpool, { name: "pushNotificationWorkpool" });
 

--- a/src/component/expo.ts
+++ b/src/component/expo.ts
@@ -3,6 +3,7 @@ import { RateLimiter } from "@convex-dev/rate-limiter";
 import type { ComponentApi as RateLimiterComponentApi } from "@convex-dev/rate-limiter/_generated/component.js";
 import { components, internal } from "./_generated/api.js";
 import type { Id } from "./_generated/dataModel.js";
+import { env } from "./_generated/server.js";
 import { internalAction } from "./functions.js";
 import { EXPO_ONE_CALL_EVERY_MS } from "./shared.js";
 
@@ -89,6 +90,9 @@ export const callExpoPushApiWithBatch = internalAction({
           Accept: "application/json",
           "Accept-encoding": "gzip, deflate",
           "Content-Type": "application/json",
+          ...(env.EXPO_ACCESS_TOKEN && {
+            Authorization: `Bearer ${env.EXPO_ACCESS_TOKEN}`,
+          }),
         },
         body: JSON.stringify(
           inProgress.map((notification) => ({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,8 @@
     "rootDir": "./src",
     "outDir": "./dist",
     "verbatimModuleSyntax": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["node"],
   },
   "include": ["./src/**/*"]
 }


### PR DESCRIPTION
Allow setting an optional `EXPO_ACCESS_TOKEN` component env var to authenticate requests to the Expo push API.