### PR TITLE
Add collapseId and tag pass-through to notification fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,13 @@ export const sendPushNotification = mutation({
 });
 ```
 
+The `notification` object supports the fields of the
+[Expo push message format](https://docs.expo.dev/push-notifications/sending-notifications/#message-request-format),
+including `collapseId` and `tag` for collapsing/replacing notifications instead
+of stacking them (on Android, `tag` replaces already-displayed notifications
+while `collapseId` only coalesces messages in transit; on iOS, `collapseId`
+does both).
+
 You can use the ID returned from `sendPushNotifications` to query the status of
 the notification using `getNotification`. Using this in a query allows you to
 subscribe to the status of a notification.

--- a/src/component/lib.test.ts
+++ b/src/component/lib.test.ts
@@ -56,6 +56,31 @@ describe("push notification pipeline", () => {
     expect(nextBatchRun!.segment).toBe(notification!.segment);
   });
 
+  it("passes collapseId and tag through to the stored notification", async () => {
+    await t.mutation(api.public.recordPushNotificationToken, {
+      userId: "user-1",
+      pushToken: "ExponentPushToken[abc123]",
+      logLevel: "ERROR",
+    });
+
+    const notificationId = await t.mutation(api.public.sendPushNotification, {
+      userId: "user-1",
+      notification: {
+        title: "hello",
+        collapseId: "task-assigned",
+        tag: "task-assigned",
+      },
+      logLevel: "ERROR",
+    });
+
+    const notification = await t.run(async (ctx: any) => {
+      return await ctx.db.get("notifications", notificationId!);
+    });
+
+    expect(notification!.metadata.collapseId).toBe("task-assigned");
+    expect(notification!.metadata.tag).toBe("task-assigned");
+  });
+
   it("maps Expo success/error response items", async () => {
     const id1 = await t.run(async (ctx: any) =>
       ctx.db.insert("notifications", {

--- a/src/component/shared.ts
+++ b/src/component/shared.ts
@@ -25,6 +25,8 @@ export const notificationFields = {
   channelId: v.optional(v.string()),
   categoryId: v.optional(v.string()),
   mutableContent: v.optional(v.boolean()),
+  collapseId: v.optional(v.string()),
+  tag: v.optional(v.string()),
 };
 
 /**
@@ -142,6 +144,26 @@ export type NotificationFields = {
    * Defaults to false.
    */
   mutableContent?: boolean;
+
+  /**
+   * Android and iOS
+   *
+   * An identifier for collapsing notifications. On Android, this only coalesces
+   * messages in transit (maps to the FCM collapse_key); use tag to also replace
+   * notifications already displayed on the device. On iOS, this both coalesces
+   * messages in transit and replaces already-displayed notifications
+   * (maps to apns-collapse-id).
+   */
+  collapseId?: string;
+
+  /**
+   * Android Only
+   *
+   * An identifier for replacing notifications already displayed on the device.
+   * If the device is already showing a notification with the same tag, the new
+   * notification replaces it. Maps to the FCM notification.tag field.
+   */
+  tag?: string;
 };
 
 export const vNotificationStatus = v.union(


### PR DESCRIPTION
## What

Adds `collapseId` and `tag` to `notificationFields` (validator + `NotificationFields` type), so senders can opt into notification collapsing/replacement instead of stacking. Pass-through is automatic: notification metadata is already spread into the Expo push API payload in `expo.ts`, so only the validator was blocking these fields.

## Why

The [Expo push message format](https://docs.expo.dev/push-notifications/sending-notifications/#message-request-format) supports both fields:

- `collapseId` (Android and iOS): coalesces messages in transit (FCM `collapse_key`); on iOS it also replaces already-displayed notifications (`apns-collapse-id`).
- `tag` (Android only): replaces already-displayed notifications (FCM `notification.tag`).

`expo-server-sdk-node` added both fields in v6.1.0 (expo/expo-server-sdk-node#266). The component currently rejects them because the validator is a closed field list, so apps sending bursts of same-type notifications (e.g. several task assignments in a row) cannot collapse them into one lock-screen entry.

## Notes

- Doc comments follow the wording of the official Expo docs, including the `collapseId`-vs-`tag` distinction on Android.
- Heads-up for consumers (not a component concern): expo/expo#44524 reports that `tag` currently surfaces in the notification identifier on Android, which can interact with client-side dedup logic.

## Test

- Added a test asserting both fields survive into the stored notification metadata.
- `npm run build`, `npm run typecheck`, `npm run lint`, `npm run test` all green (17/17).