### PR TITLE
add LOG_LEVEL component env var and deprecate config field

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -23,18 +23,21 @@ const RECORD_TOKEN_BATCH_SIZE = 1000;
  */
 export class PushNotifications<UserType extends string = GenericId<"users">> {
   private config: {
-    logLevel: LogLevel;
+    logLevel?: LogLevel;
   };
   constructor(
     public component: ComponentApi,
     config?: {
+      /**
+       * @deprecated Set the `LOG_LEVEL` component environment variable instead.
+       */
       logLevel?: LogLevel;
     },
   ) {
     this.component = component;
     this.config = {
       ...(config ?? {}),
-      logLevel: config?.logLevel ?? "ERROR",
+      logLevel: config?.logLevel,
     };
   }
 

--- a/src/component/_generated/component.ts
+++ b/src/component/_generated/component.ts
@@ -27,14 +27,14 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
       deleteNotificationsForUser: FunctionReference<
         "mutation",
         "internal",
-        { logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR"; userId: string },
+        { logLevel?: "DEBUG" | "INFO" | "WARN" | "ERROR"; userId: string },
         null,
         Name
       >;
       getNotification: FunctionReference<
         "query",
         "internal",
-        { id: string; logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR" },
+        { id: string; logLevel?: "DEBUG" | "INFO" | "WARN" | "ERROR" },
         null | {
           _contentAvailable?: boolean;
           _creationTime: number;
@@ -72,7 +72,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         "internal",
         {
           limit?: number;
-          logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR";
+          logLevel?: "DEBUG" | "INFO" | "WARN" | "ERROR";
           userId: string;
         },
         Array<{
@@ -111,14 +111,14 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
       getStatusForUser: FunctionReference<
         "query",
         "internal",
-        { logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR"; userId: string },
+        { logLevel?: "DEBUG" | "INFO" | "WARN" | "ERROR"; userId: string },
         { hasToken: boolean; paused: boolean },
         Name
       >;
       pauseNotificationsForUser: FunctionReference<
         "mutation",
         "internal",
-        { logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR"; userId: string },
+        { logLevel?: "DEBUG" | "INFO" | "WARN" | "ERROR"; userId: string },
         null,
         Name
       >;
@@ -126,7 +126,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         "mutation",
         "internal",
         {
-          logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR";
+          logLevel?: "DEBUG" | "INFO" | "WARN" | "ERROR";
           pushToken: string;
           userId: string;
         },
@@ -137,7 +137,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         "mutation",
         "internal",
         {
-          logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR";
+          logLevel?: "DEBUG" | "INFO" | "WARN" | "ERROR";
           tokens: Array<{ pushToken: string; userId: string }>;
         },
         null,
@@ -146,14 +146,14 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
       removePushNotificationToken: FunctionReference<
         "mutation",
         "internal",
-        { logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR"; userId: string },
+        { logLevel?: "DEBUG" | "INFO" | "WARN" | "ERROR"; userId: string },
         null,
         Name
       >;
       restart: FunctionReference<
         "mutation",
         "internal",
-        { logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR" },
+        { logLevel?: "DEBUG" | "INFO" | "WARN" | "ERROR" },
         boolean,
         Name
       >;
@@ -162,7 +162,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         "internal",
         {
           allowUnregisteredTokens?: boolean;
-          logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR";
+          logLevel?: "DEBUG" | "INFO" | "WARN" | "ERROR";
           notification: {
             _contentAvailable?: boolean;
             badge?: number;
@@ -193,7 +193,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         "internal",
         {
           allowUnregisteredTokens?: boolean;
-          logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR";
+          logLevel?: "DEBUG" | "INFO" | "WARN" | "ERROR";
           notifications: Array<{
             notification: {
               _contentAvailable?: boolean;
@@ -224,14 +224,14 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
       shutdown: FunctionReference<
         "mutation",
         "internal",
-        { logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR" },
+        { logLevel?: "DEBUG" | "INFO" | "WARN" | "ERROR" },
         { data?: any; message: string },
         Name
       >;
       unpauseNotificationsForUser: FunctionReference<
         "mutation",
         "internal",
-        { logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR"; userId: string },
+        { logLevel?: "DEBUG" | "INFO" | "WARN" | "ERROR"; userId: string },
         null,
         Name
       >;

--- a/src/component/_generated/server.ts
+++ b/src/component/_generated/server.ts
@@ -35,6 +35,7 @@ import type { DataModel } from "./dataModel.js";
  */
 type Env = {
   readonly EXPO_ACCESS_TOKEN: string | undefined;
+  readonly LOG_LEVEL: "DEBUG" | "INFO" | "WARN" | "ERROR" | undefined;
 };
 
 /**

--- a/src/component/convex.config.ts
+++ b/src/component/convex.config.ts
@@ -2,10 +2,12 @@ import { defineComponent } from "convex/server";
 import { v } from "convex/values";
 import rateLimiter from "@convex-dev/rate-limiter/convex.config";
 import workpool from "@convex-dev/workpool/convex.config";
+import { logLevelValidator } from "../logging/index.js";
 
 const component = defineComponent("pushNotifications", {
   env: {
     EXPO_ACCESS_TOKEN: v.optional(v.string()),
+    LOG_LEVEL: v.optional(logLevelValidator),
   },
 });
 component.use(rateLimiter);

--- a/src/component/functions.ts
+++ b/src/component/functions.ts
@@ -5,47 +5,52 @@ import {
   customQuery,
 } from "convex-helpers/server/customFunctions";
 import * as VanillaConvex from "./_generated/server.js";
-import { Logger, logLevelValidator } from "../logging/index.js";
+import { env } from "./_generated/server.js";
+import { Logger, logLevelValidator, type LogLevel } from "../logging/index.js";
+import { v } from "convex/values";
+
+const resolveLogLevel = (logLevel?: LogLevel): LogLevel =>
+  logLevel ?? env.LOG_LEVEL ?? "ERROR";
 
 export const query = customQuery(VanillaConvex.query, {
-  args: { logLevel: logLevelValidator },
+  args: { logLevel: v.optional(logLevelValidator) },
   input: async (ctx, args) => {
-    return { ctx: { logger: new Logger(args.logLevel) }, args: {} };
+    return { ctx: { logger: new Logger(resolveLogLevel(args.logLevel)) }, args: {} };
   },
 });
 
 export const mutation = customMutation(VanillaConvex.mutation, {
-  args: { logLevel: logLevelValidator },
+  args: { logLevel: v.optional(logLevelValidator) },
   input: async (ctx, args) => {
-    return { ctx: { logger: new Logger(args.logLevel) }, args: {} };
+    return { ctx: { logger: new Logger(resolveLogLevel(args.logLevel)) }, args: {} };
   },
 });
 
 export const action = customAction(VanillaConvex.action, {
-  args: { logLevel: logLevelValidator },
+  args: { logLevel: v.optional(logLevelValidator) },
   input: async (ctx, args) => {
-    return { ctx: { logger: new Logger(args.logLevel) }, args: {} };
+    return { ctx: { logger: new Logger(resolveLogLevel(args.logLevel)) }, args: {} };
   },
 });
 
 export const internalQuery = customQuery(VanillaConvex.internalQuery, {
-  args: { logLevel: logLevelValidator },
+  args: { logLevel: v.optional(logLevelValidator) },
   input: async (ctx, args) => {
-    return { ctx: { logger: new Logger(args.logLevel) }, args: {} };
+    return { ctx: { logger: new Logger(resolveLogLevel(args.logLevel)) }, args: {} };
   },
 });
 
 export const internalMutation = customMutation(VanillaConvex.internalMutation, {
-  args: { logLevel: logLevelValidator },
+  args: { logLevel: v.optional(logLevelValidator) },
   input: async (ctx, args) => {
-    return { ctx: { logger: new Logger(args.logLevel) }, args: {} };
+    return { ctx: { logger: new Logger(resolveLogLevel(args.logLevel)) }, args: {} };
   },
 });
 
 export const internalAction = customAction(VanillaConvex.internalAction, {
-  args: { logLevel: logLevelValidator },
+  args: { logLevel: v.optional(logLevelValidator) },
   input: async (ctx, args) => {
-    return { ctx: { logger: new Logger(args.logLevel) }, args: {} };
+    return { ctx: { logger: new Logger(resolveLogLevel(args.logLevel)) }, args: {} };
   },
 });
 


### PR DESCRIPTION
add LOG_LEVEL component env var and `@deprecate` the config field. 

we need to keep logLevel in the function arguments for backwards compatibility (e.g. in case there are previously scheduled functions that have logLevel as an argument).