### PR TITLE
add initialBackoffMs and retryAttempts config options

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -8,6 +8,7 @@ import type { GenericId } from "convex/values";
 import type { NotificationFields } from "../component/schema.js";
 import type { LogLevel } from "../logging/index.js";
 import type { ComponentApi } from "../component/_generated/component.js";
+import { DEFAULT_RUNTIME_CONFIG, type RuntimeConfig } from "../component/shared.js";
 
 const RECORD_TOKEN_BATCH_SIZE = 1000;
 
@@ -23,6 +24,7 @@ const RECORD_TOKEN_BATCH_SIZE = 1000;
  */
 export class PushNotifications<UserType extends string = GenericId<"users">> {
   private logLevel?: LogLevel;
+  private runtimeConfig: RuntimeConfig;
   constructor(
     public component: ComponentApi,
     config?: {
@@ -30,10 +32,27 @@ export class PushNotifications<UserType extends string = GenericId<"users">> {
        * @deprecated Set the `LOG_LEVEL` component environment variable instead.
        */
       logLevel?: LogLevel;
+      /**
+       * Base delay in milliseconds for the exponential backoff applied between
+       * delivery retries. Retry N waits `initialBackoffMs * 2 ** (N - 1)` ms,
+       * capped at 15 minutes. Defaults to 500.
+       */
+      initialBackoffMs?: number;
+      /**
+       * Maximum number of delivery attempts for a notification before it is
+       * marked `unable_to_deliver`. Defaults to 5.
+       */
+      retryAttempts?: number;
     },
   ) {
     this.component = component;
     this.logLevel = config?.logLevel;
+    this.runtimeConfig = {
+      initialBackoffMs:
+        config?.initialBackoffMs ?? DEFAULT_RUNTIME_CONFIG.initialBackoffMs,
+      retryAttempts:
+        config?.retryAttempts ?? DEFAULT_RUNTIME_CONFIG.retryAttempts,
+    };
   }
 
   /**
@@ -135,6 +154,7 @@ export class PushNotifications<UserType extends string = GenericId<"users">> {
     return ctx.runMutation(this.component.public.sendPushNotification, {
       ...args,
       logLevel: this.logLevel,
+      runtimeConfig: this.runtimeConfig,
     });
   }
 
@@ -158,6 +178,7 @@ export class PushNotifications<UserType extends string = GenericId<"users">> {
     return ctx.runMutation(this.component.public.sendPushNotificationBatch, {
       ...args,
       logLevel: this.logLevel,
+      runtimeConfig: this.runtimeConfig,
     });
   }
 

--- a/src/component/_generated/component.ts
+++ b/src/component/_generated/component.ts
@@ -183,6 +183,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
             title?: string;
             ttl?: number;
           };
+          runtimeConfig?: { initialBackoffMs: number; retryAttempts: number };
           userId: string;
         },
         string | null,
@@ -217,6 +218,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
             };
             userId: string;
           }>;
+          runtimeConfig?: { initialBackoffMs: number; retryAttempts: number };
         },
         Array<string | null>,
         Name

--- a/src/component/batch.ts
+++ b/src/component/batch.ts
@@ -155,10 +155,14 @@ async function syncNextBatchRun(
 
 export async function scheduleBatchRun(
   ctx: SchedulingCtx,
-  options: RuntimeConfig,
+  options?: RuntimeConfig,
   minimumSegment?: number,
 ) {
-  await upsertRuntimeConfig(ctx, options);
+  // Only persist config when the caller supplied it; omitting it (e.g. on
+  // restart) leaves the previously stored runtime config untouched.
+  if (options) {
+    await upsertRuntimeConfig(ctx, options);
+  }
 
   if (await isShuttingDown(ctx)) {
     return;

--- a/src/component/helpers.ts
+++ b/src/component/helpers.ts
@@ -1,9 +1,12 @@
 import type { MutationCtx } from "./functions.js";
-import { DEFAULT_RUNTIME_CONFIG } from "./shared.js";
+import type { RuntimeConfig } from "./shared.js";
 import { cancelPendingBatches, scheduleBatchRun } from "./batch.js";
 
-export async function ensureBatchRunScheduled(ctx: MutationCtx) {
-  await scheduleBatchRun(ctx, DEFAULT_RUNTIME_CONFIG);
+export async function ensureBatchRunScheduled(
+  ctx: MutationCtx,
+  config?: RuntimeConfig,
+) {
+  await scheduleBatchRun(ctx, config);
 }
 
 export const shutdownGracefully = async (ctx: MutationCtx) => {

--- a/src/component/public.ts
+++ b/src/component/public.ts
@@ -1,6 +1,6 @@
 import { ConvexError, v, type Infer } from "convex/values";
 import { mutation, query, type MutationCtx } from "./functions.js";
-import { BASE_BATCH_DELAY, getFutureSegment } from "./shared.js";
+import { BASE_BATCH_DELAY, getFutureSegment, vRuntimeConfig } from "./shared.js";
 import {
   notificationFields,
   notificationState,
@@ -96,6 +96,7 @@ const sendPushNotificationArgs = v.object({
   userId: v.string(),
   notification: v.object(notificationFields),
   allowUnregisteredTokens: v.optional(v.boolean()),
+  runtimeConfig: v.optional(vRuntimeConfig),
 });
 
 export const sendPushNotification = mutation({
@@ -103,7 +104,7 @@ export const sendPushNotification = mutation({
   returns: v.union(v.id("notifications"), v.null()),
   handler: async (ctx, args) => {
     const result = await sendPushNotificationHandler(ctx, args);
-    await ensureBatchRunScheduled(ctx);
+    await ensureBatchRunScheduled(ctx, args.runtimeConfig);
     return result;
   },
 });
@@ -117,6 +118,7 @@ export const sendPushNotificationBatch = mutation({
       }),
     ),
     allowUnregisteredTokens: v.optional(v.boolean()),
+    runtimeConfig: v.optional(vRuntimeConfig),
   },
   returns: v.array(v.union(v.id("notifications"), v.null())),
   handler: async (ctx, args) => {
@@ -129,7 +131,7 @@ export const sendPushNotificationBatch = mutation({
       });
       results.push(result);
     }
-    await ensureBatchRunScheduled(ctx);
+    await ensureBatchRunScheduled(ctx, args.runtimeConfig);
     return results;
   },
 });


### PR DESCRIPTION
There wasn't a way for users to set `initialBackoffMs` and `retryAttempts` yet (besides in the dashboard), so this wires it up to add them to the client